### PR TITLE
Currently, if two serverparks have the same survey they will overwrit…

### DIFF
--- a/BlaiseCaseBackup.Tests/BlaiseCaseBackup.Tests.csproj
+++ b/BlaiseCaseBackup.Tests/BlaiseCaseBackup.Tests.csproj
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Blaise.Nuget.Api.Contracts, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Blaise.Nuget.Api.Contracts.2020.9.1.2\lib\net472\Blaise.Nuget.Api.Contracts.dll</HintPath>
+      <HintPath>..\packages\Blaise.Nuget.Api.Contracts.2020.9.1.3\lib\net472\Blaise.Nuget.Api.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>

--- a/BlaiseCaseBackup.Tests/packages.config
+++ b/BlaiseCaseBackup.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Blaise.Nuget.Api.Contracts" version="2020.9.1.2" targetFramework="net472" />
+  <package id="Blaise.Nuget.Api.Contracts" version="2020.9.1.3" targetFramework="net472" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net472" />
   <package id="log4net" version="2.0.8" targetFramework="net472" />
   <package id="Moq" version="4.14.4" targetFramework="net472" />

--- a/BlaiseCaseBackup/BlaiseCaseBackup.csproj
+++ b/BlaiseCaseBackup/BlaiseCaseBackup.csproj
@@ -40,13 +40,13 @@
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Blaise.Nuget.Api, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Blaise.Nuget.Api.2020.9.1.2\lib\net472\Blaise.Nuget.Api.dll</HintPath>
+      <HintPath>..\packages\Blaise.Nuget.Api.2020.9.1.3\lib\net472\Blaise.Nuget.Api.dll</HintPath>
     </Reference>
     <Reference Include="Blaise.Nuget.Api.Contracts, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Blaise.Nuget.Api.Contracts.2020.9.1.2\lib\net472\Blaise.Nuget.Api.Contracts.dll</HintPath>
+      <HintPath>..\packages\Blaise.Nuget.Api.Contracts.2020.9.1.3\lib\net472\Blaise.Nuget.Api.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Blaise.Nuget.Api.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Blaise.Nuget.Api.2020.9.1.2\lib\net472\Blaise.Nuget.Api.Core.dll</HintPath>
+      <HintPath>..\packages\Blaise.Nuget.Api.2020.9.1.3\lib\net472\Blaise.Nuget.Api.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.0\lib\net45\EntityFramework.dll</HintPath>

--- a/BlaiseCaseBackup/Interfaces/IConfigurationProvider.cs
+++ b/BlaiseCaseBackup/Interfaces/IConfigurationProvider.cs
@@ -4,5 +4,7 @@
     {
         string TimerIntervalInMinutes { get; }
         string BucketName { get; }
+
+        string VmName { get; }
     }
 }

--- a/BlaiseCaseBackup/Providers/ConfigurationProvider.cs
+++ b/BlaiseCaseBackup/Providers/ConfigurationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using BlaiseCaseBackup.Interfaces;
 
 namespace BlaiseCaseBackup.Providers
@@ -8,5 +9,7 @@ namespace BlaiseCaseBackup.Providers
         public string TimerIntervalInMinutes => ConfigurationManager.AppSettings["TimerIntervalInMinutes"];
 
         public string BucketName => ConfigurationManager.AppSettings["BucketName"];
+
+        public string VmName => Environment.MachineName;
     }
 }

--- a/BlaiseCaseBackup/Services/BackupSurveysService.cs
+++ b/BlaiseCaseBackup/Services/BackupSurveysService.cs
@@ -27,7 +27,7 @@ namespace BlaiseCaseBackup.Services
                     .WithConnection(_blaiseApi.DefaultConnection)
                     .Surveys)
             {
-                _logger.Info($"Processing survey '{survey.Name}' for server park '{survey.ServerPark}'");
+                _logger.Info($"Processing survey '{survey.Name}' for server park '{survey.ServerPark}' on '{_configurationProvider.VmName}'");
 
                 _blaiseApi
                     .WithConnection(_blaiseApi.DefaultConnection)
@@ -37,7 +37,7 @@ namespace BlaiseCaseBackup.Services
                     .ToBucket(_configurationProvider.BucketName)
                     .Backup();
 
-                _logger.Info($"Backed up survey '{survey.Name}' for server park '{survey.ServerPark}' to bucket '{_configurationProvider.BucketName}'");
+                _logger.Info($"Backed up survey '{survey.Name}' for server park '{survey.ServerPark}' to bucket '{_configurationProvider.BucketName}' on '{_configurationProvider.VmName}'");
             }
         }
     }

--- a/BlaiseCaseBackup/Services/InitialiseService.cs
+++ b/BlaiseCaseBackup/Services/InitialiseService.cs
@@ -32,12 +32,12 @@ namespace BlaiseCaseBackup.Services
             timer.Elapsed += BackupSurveys;
             timer.Start();
 
-            _logger.Info("Blaise Case Backup service started.");
+            _logger.Info($"Blaise Case Backup service started on '{_configurationProvider.VmName}'");
         }
 
         public void Stop()
         {
-            _logger.Info("Blaise Case Backup service stopped.");
+            _logger.Info($"Blaise Case Backup service stopped  on '{_configurationProvider.VmName}'");
         }
 
         private void BackupSurveys(object sender, ElapsedEventArgs args)

--- a/BlaiseCaseBackup/packages.config
+++ b/BlaiseCaseBackup/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net472" />
-  <package id="Blaise.Nuget.Api" version="2020.9.1.2" targetFramework="net472" />
-  <package id="Blaise.Nuget.Api.Contracts" version="2020.9.1.2" targetFramework="net472" />
+  <package id="Blaise.Nuget.Api" version="2020.9.1.3" targetFramework="net472" />
+  <package id="Blaise.Nuget.Api.Contracts" version="2020.9.1.3" targetFramework="net472" />
   <package id="EntityFramework" version="6.4.0" targetFramework="net472" />
   <package id="Google.Api.Gax" version="3.0.0" targetFramework="net472" />
   <package id="Google.Api.Gax.Rest" version="3.0.0" targetFramework="net472" />


### PR DESCRIPTION
…e each other upon a backup. This change will create a subfolder in the the bucket with the name of the serverpark